### PR TITLE
서대륙 복귀 퀘스트 해결

### DIFF
--- a/tome-krtr-v1.3.3.teaa/overload/data/chats/zemekkys.lua
+++ b/tome-krtr-v1.3.3.teaa/overload/data/chats/zemekkys.lua
@@ -18,11 +18,11 @@
 -- darkgod@te4.org
 
 local function remove_materials(npc, player)
-	local gem_o, gem_item, gem_inven_id = player:findInAllInventories("Resonating Diamond")
+	local gem_o, gem_item, gem_inven_id = player:findInAllInventories("공명하는 다이아몬드")
 	player:removeObject(gem_inven_id, gem_item, false)
 	gem_o:removed()
 
-	local athame_o, athame_item, athame_inven_id = player:findInAllInventories("Blood-Runed Athame")
+	local athame_o, athame_item, athame_inven_id = player:findInAllInventories("피의 룬 제례단검")
 	player:removeObject(athame_inven_id, athame_item, false)
 	athame_o:removed()
 
@@ -30,8 +30,8 @@ local function remove_materials(npc, player)
 end
 
 local function check_materials(npc, player)
-	local gem_o, gem_item, gem_inven_id = player:findInAllInventories("Resonating Diamond")
-	local athame_o, athame_item, athame_inven_id = player:findInAllInventories("Blood-Runed Athame")
+	local gem_o, gem_item, gem_inven_id = player:findInAllInventories("공명하는 다이아몬드")
+	local athame_o, athame_item, athame_inven_id = player:findInAllInventories("피의 룬 제례단검")
 	return gem_o and athame_o and player.money >= 100
 end
 


### PR DESCRIPTION
아이템 이름 때문이었군요.. 그런데 이걸 고치는 거 보다 아이템 쪽을 고치는 게 나을까요? 아이템이 어느 파일에 있는지 몰라서 일단 이렇게 고칩니다. 

이걸로 실행해보면 제대로 작동하는 것은 확인은 했습니다.